### PR TITLE
tweak to support missing data

### DIFF
--- a/pages/items/[id].tsx
+++ b/pages/items/[id].tsx
@@ -6,13 +6,31 @@ import path from "path";
 import Header from "../../components/header";
 
 type Props = {
+  fileData: any;
   actionsData: any;
   chatgptData: any;
 };
 
-export default function ItemPage({ actionsData, chatgptData }: Props) {
-  console.log(actionsData);
-  const lastVote = actionsData.find((action) => action.votes.length !== 0);
+const EMPTY_CHATGPT_RESPONSE = {
+  "Before Change": "N/A",
+  "Proposed Change": "N/A",
+  Impact: "N/A",
+  Rationale: "N/A",
+  "Approval Process": "N/A",
+  Accountability: "N/A",
+};
+
+const EMPTY_ACTION = {
+  votes: [],
+};
+
+export default function ItemPage({
+  fileData,
+  actionsData,
+  chatgptData,
+}: Props) {
+  const lastVote =
+    actionsData.find((action) => action.votes.length !== 0) || EMPTY_ACTION;
   return (
     <Layout>
       <Container>
@@ -20,22 +38,32 @@ export default function ItemPage({ actionsData, chatgptData }: Props) {
         <section className="mx-4 mt-4">
           <div className="text-sm font-medium text-stone-600">
             <span>Latest status: </span>
-            <span className="lowercase">{actionsData[0]["action"]} by {actionsData[0]["actionBy"]}</span>
+            <span className="lowercase">
+              {actionsData[0]["action"]} by {actionsData[0]["actionBy"]}
+            </span>
           </div>
-          <div className="text-xl font-extrabold">Cash Revolving Funds</div>
+          <div className="text-xl font-extrabold">{fileData["Name"]}</div>
         </section>
         <section className="mx-4 mt-4">
-          <div className="text-sm font-medium text-stone-600">Current state</div>
+          <div className="text-sm font-medium text-stone-600">
+            Current state
+          </div>
           <div className="mb-6">{chatgptData["Before Change"]}</div>
-          <div className="text-sm font-medium text-stone-600">Proposed changes</div>
+          <div className="text-sm font-medium text-stone-600">
+            Proposed changes
+          </div>
           <div className="mb-6">{chatgptData["Proposed Change"]}</div>
           <div className="text-sm font-medium text-stone-600">Impact</div>
           <div className="mb-6">{chatgptData["Impact"]}</div>
           <div className="text-sm font-medium text-stone-600">Rationale</div>
           <div className="mb-6">{chatgptData["Rationale"]}</div>
-          <div className="text-sm font-medium text-stone-600">Approval process</div>
+          <div className="text-sm font-medium text-stone-600">
+            Approval process
+          </div>
           <div className="mb-6">{chatgptData["Approval Process"]}</div>
-          <div className="text-sm font-medium text-stone-600">Accountability</div>
+          <div className="text-sm font-medium text-stone-600">
+            Accountability
+          </div>
           <div className="mb-6">{chatgptData["Accountability"]}</div>
 
           <div className="mb-6 rounded-md border p-3 text-xs text-stone-600">
@@ -43,12 +71,23 @@ export default function ItemPage({ actionsData, chatgptData }: Props) {
             this legislation, which you can find below.
           </div>
         </section>
-        <section className="mx-4 mt-4 mb-8 bg-white p-4 rounded-lg border flex flex-col gap-2">
-          <div className="text-sm text-stone-600">How the board voted on the latest version</div>
+        <section className="mx-4 mb-8 mt-4 flex flex-col gap-2 rounded-lg border bg-white p-4">
+          <div className="text-sm text-stone-600">
+            How the board voted on the latest version
+          </div>
           {lastVote.votes.map((vote, index) => (
-            <div key={index} className="flex justify-between text-sm font-medium">
+            <div
+              key={index}
+              className="flex justify-between text-sm font-medium"
+            >
               <span>{vote.person}</span>
-              <span className={vote.vote === "No" ? "text-red-600" : "text-green-600"}>{vote.vote}</span>
+              <span
+                className={
+                  vote.vote === "No" ? "text-red-600" : "text-green-600"
+                }
+              >
+                {vote.vote}
+              </span>
             </div>
           ))}
         </section>
@@ -62,16 +101,21 @@ export async function getStaticProps({ params }) {
   const server = "https://sfgov.s3.us-east-1.amazonaws.com";
 
   // Construct the URLs using the id from params
+  const fileURL = `${server}/files/${id}.json`;
   const actionsURL = `${server}/actions/${id}.json`;
   const chatgptURL = `${server}/chatgpt/${id}.json`;
 
   // Fetch data from each URL
+  const fileData = await fetch(fileURL).then((res) => res.json());
   const actionsData = await fetch(actionsURL).then((res) => res.json());
-  const chatgptData = await fetch(chatgptURL).then((res) => res.json());
+  const chatgptData = await fetch(chatgptURL)
+    .then((res) => res.json())
+    .catch(() => EMPTY_CHATGPT_RESPONSE); // if chatgpt summary doesn't exist, just return empty summary
 
   // Pass the fetched data to the page via props
   return {
     props: {
+      fileData,
       actionsData,
       chatgptData,
     },


### PR DESCRIPTION
Noticed a couple things:
- all data is fetched via the `id` of the file, therefore, introduced a new `files/[id].json` folder in s3 to fetch the file names
- sometimes we do not have a chatGPT summary, so give it an empty one if it does not exist (ie for all resolutions)
- sometimes we do not have any votes for an action, so use a fallback empty action so the app doesn't crash

That all said, noticing that we have still have 3 broken pages. A couple of them appear to be ordinances which is slightly concerning, but they seem to be from a while back

```
> Export encountered errors on following paths:
	/items/[id]: /items/220886
	/items/[id]: /items/220961
	/items/[id]: /items/230562
```